### PR TITLE
remove go mod tidy

### DIFF
--- a/go_module/Dockerfile
+++ b/go_module/Dockerfile
@@ -28,7 +28,6 @@ WORKDIR $GOPATH/src/mypackage/myapp/
 COPY go.mod .
 
 ENV GO111MODULE=on
-RUN go mod tidy
 RUN go mod download
 RUN go mod verify
 

--- a/go_module_distroless/Dockerfile
+++ b/go_module_distroless/Dockerfile
@@ -14,7 +14,6 @@ WORKDIR $GOPATH/src/mypackage/myapp/
 COPY go.mod .
 
 ENV GO111MODULE=on
-RUN go mod tidy
 RUN go mod download
 RUN go mod verify
 

--- a/go_module_distroless_static/Dockerfile
+++ b/go_module_distroless_static/Dockerfile
@@ -14,7 +14,6 @@ WORKDIR $GOPATH/src/mypackage/myapp/
 COPY go.mod .
 
 ENV GO111MODULE=on
-RUN go mod tidy
 RUN go mod download
 RUN go mod verify
 


### PR DESCRIPTION
In my case with Go 1.14 this isn't working properly, because go mod tidy
is removing all dependencies which are not found in source files.
But the source files are copied only after go mod verify. So there are
no dependencies downloaded with go mod download and needs to be downloaded
during go build every time.