### PR TITLE
Splits multiline commands onto individual lines in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,33 +31,38 @@ docker-pull-distroless:	## - docker pull latest images
 build:docker-pull	## - Build the smallest and secured golang docker image based on scratch
 	@printf "\033[32m\xE2\x9c\x93 Build the smallest and secured golang docker image based on scratch\n\033[0m"
 	$(eval BUILDER_IMAGE=$(shell docker inspect --format='{{index .RepoDigests 0}}' golang:alpine))
-	@export DOCKER_CONTENT_TRUST=1 && docker build -f docker/scratch.Dockerfile --build-arg "BUILDER_IMAGE=$(BUILDER_IMAGE)" -t smallest-secured-golang .
+	@export DOCKER_CONTENT_TRUST=1
+	@docker build -f docker/scratch.Dockerfile --build-arg "BUILDER_IMAGE=$(BUILDER_IMAGE)" -t smallest-secured-golang .
 
 .PHONY: build-module
 build-module:docker-pull	## - Build the smallest and secured golang docker image based on scratch
 	@printf "\033[32m\xE2\x9c\x93 Build the smallest and secured golang docker image based on scratch\n\033[0m"
 	$(eval BUILDER_IMAGE=$(shell docker inspect --format='{{index .RepoDigests 0}}' golang:alpine))
-	@export DOCKER_CONTENT_TRUST=1 && docker build -f docker/scratch_module.Dockerfile --build-arg "BUILDER_IMAGE=$(BUILDER_IMAGE)" -t smallest-secured-golang .
+	@export DOCKER_CONTENT_TRUST=1
+	@docker build -f docker/scratch_module.Dockerfile --build-arg "BUILDER_IMAGE=$(BUILDER_IMAGE)" -t smallest-secured-golang .
 
 .PHONY: build-distroless
 build-distroless:docker-pull-distroless	## - Build the smallest and secured golang docker image based on distroless
 	@printf "\033[32m\xE2\x9c\x93 Build the smallest and secured golang docker image based on distroless\n\033[0m"
 	$(eval BUILDER_IMAGE=$(shell docker inspect --format='{{index .RepoDigests 0}}' golang:buster))
 	$(eval DISTROLESS_IMAGE=$(shell docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base))
-	@export DOCKER_CONTENT_TRUST=1 && docker build -f docker/distroless.Dockerfile --build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) --build-arg DISTROLESS_IMAGE=$(DISTROLESS_IMAGE) -t smallest-secured-golang-distroless .
+	@export DOCKER_CONTENT_TRUST=1
+	@docker build -f docker/distroless.Dockerfile --build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) --build-arg DISTROLESS_IMAGE=$(DISTROLESS_IMAGE) -t smallest-secured-golang-distroless .
 
 .PHONY: build-distroless-static
 build-distroless-static:docker-pull-distroless	## - Build the smallest and secured golang docker image based on distroless static
 	@printf "\033[32m\xE2\x9c\x93 Build the smallest and secured golang docker image based on distroless static\n\033[0m"
 	$(eval BUILDER_IMAGE=$(shell docker inspect --format='{{index .RepoDigests 0}}' golang:buster))
 	$(eval DISTROLESS_IMAGE=$(shell docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/static))
-	@export DOCKER_CONTENT_TRUST=1 && docker build -f docker/distroless_static.Dockerfile --build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) --build-arg DISTROLESS_IMAGE=$(DISTROLESS_IMAGE) -t smallest-secured-golang-distroless-static .
+	@export DOCKER_CONTENT_TRUST=1
+	@docker build -f docker/distroless_static.Dockerfile --build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) --build-arg DISTROLESS_IMAGE=$(DISTROLESS_IMAGE) -t smallest-secured-golang-distroless-static .
 
 .PHONY: build-no-cache
 build-no-cache:docker-pull	## - Build the smallest and secured golang docker image based on scratch with no cache
 	@printf "\033[32m\xE2\x9c\x93 Build the smallest and secured golang docker image based on scratch\n\033[0m"
 	$(eval BUILDER_IMAGE=$(shell docker inspect --format='{{index .RepoDigests 0}}' golang:alpine))
-	@export DOCKER_CONTENT_TRUST=1 && docker build --no-cache -f docker/scratch.Dockerfile --build-arg "BUILDER_IMAGE=$(BUILDER_IMAGE)" -t smallest-secured-golang .
+	@export DOCKER_CONTENT_TRUST=1
+	@docker build --no-cache -f docker/scratch.Dockerfile --build-arg "BUILDER_IMAGE=$(BUILDER_IMAGE)" -t smallest-secured-golang .
 
 .PHONY: ls
 ls: ## - List 'smallest-secured-golang' docker images


### PR DESCRIPTION
When running in VS Code bash shell on windows, all of the make build commands give an error: invalid reference format: repository name must be lowercase

This has been resolved by splitting the export and docker commands onto separate lines