### PR TITLE
'go mod download' and 'go mod verify' combined in one Docker RUN

### DIFF
--- a/docker/distroless.Dockerfile
+++ b/docker/distroless.Dockerfile
@@ -14,8 +14,7 @@ WORKDIR $GOPATH/src/mypackage/myapp/
 COPY go.mod .
 
 ENV GO111MODULE=on
-RUN go mod download
-RUN go mod verify
+RUN go mod download && go mod verify
 
 COPY . .
 

--- a/docker/distroless_static.Dockerfile
+++ b/docker/distroless_static.Dockerfile
@@ -14,8 +14,7 @@ WORKDIR $GOPATH/src/mypackage/myapp/
 COPY go.mod .
 
 ENV GO111MODULE=on
-RUN go mod download
-RUN go mod verify
+RUN go mod download && go mod verify
 
 COPY . .
 

--- a/docker/scratch_module.Dockerfile
+++ b/docker/scratch_module.Dockerfile
@@ -28,8 +28,7 @@ WORKDIR $GOPATH/src/mypackage/myapp/
 COPY go.mod .
 
 ENV GO111MODULE=on
-RUN go mod download
-RUN go mod verify
+RUN go mod download && go mod verify
 
 COPY . .
 


### PR DESCRIPTION
This is a tiny optimization. Running both commands in one RUN command reduces the created Docker layers by one. General advice can be seen at https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers, the actual example is from https://hub.docker.com/_/golang
Of course, as this is a multi-stage Docker build, reducing the layers does not affect the final Docker image (but the build process)