### PR TITLE
Reosolving issue 32, restructure for modern golang application and add cache feature for distroless files

### DIFF
--- a/docker/distroless.Dockerfile
+++ b/docker/distroless.Dockerfile
@@ -1,4 +1,4 @@
-ARG  BUILDER_IMAGE=golang:buster
+ARG  BUILDER_IMAGE=golang:1.22-alpine
 ARG  DISTROLESS_IMAGE=gcr.io/distroless/base
 ############################
 # STEP 1 build executable binary
@@ -8,18 +8,22 @@ FROM ${BUILDER_IMAGE} as builder
 # Ensure ca-certficates are up to date
 RUN update-ca-certificates
 
-WORKDIR $GOPATH/src/mypackage/myapp/
+# Set the working directory to the root of your Go module
+WORKDIR /myapp
+
+# Add cache for faster builds
+ENV GOCACHE=$HOME/.cache/go-build
+RUN --mount=type=cache,target=$GOCACHE
 
 # use modules
 COPY go.mod .
 
-ENV GO111MODULE=on
 RUN go mod download && go mod verify
 
 COPY . .
 
 # Build the binary
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -a -installsuffix cgo -o /go/bin/hello .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -a -installsuffix cgo -o /myapp/hello .
 
 ############################
 # STEP 2 build a small image
@@ -29,7 +33,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -a -installsuffix cgo -o 
 FROM ${DISTROLESS_IMAGE}
 
 # Copy our static executable
-COPY --from=builder /go/bin/hello /go/bin/hello
+COPY --from=builder /myapp/hello /myapp/hello
 
 # Run the hello binary.
-ENTRYPOINT ["/go/bin/hello"]
+ENTRYPOINT ["/myapp/hello"]

--- a/docker/distroless_static.Dockerfile
+++ b/docker/distroless_static.Dockerfile
@@ -37,4 +37,4 @@ FROM ${DISTROLESS_IMAGE}
 COPY --from=builder /myapp/hello /myapp/hello
 
 # Run the hello binary.
-ENTRYPOINT ["/myapp/hello"]:
+ENTRYPOINT ["/myapp/hello"]

--- a/docker/distroless_static.Dockerfile
+++ b/docker/distroless_static.Dockerfile
@@ -1,5 +1,6 @@
-ARG  BUILDER_IMAGE=golang:buster
-ARG  DISTROLESS_IMAGE=gcr.io/distroless/static
+ARG BUILDER_IMAGE=golang:1.22-alpine
+ARG DISTROLESS_IMAGE=gcr.io/distroless/static
+
 ############################
 # STEP 1 build executable binary
 ############################
@@ -8,20 +9,22 @@ FROM ${BUILDER_IMAGE} as builder
 # Ensure ca-certficates are up to date
 RUN update-ca-certificates
 
-WORKDIR $GOPATH/src/mypackage/myapp/
+# Set the working directory to the root of your Go module
+WORKDIR /myapp
 
-# use modules
+# Add cache for faster builds
+ENV GOCACHE=$HOME/.cache/go-build
+RUN --mount=type=cache,target=$GOCACHE
+
+# Use modules
 COPY go.mod .
-
-ENV GO111MODULE=on
 RUN go mod download && go mod verify
 
+# Copy the source code and build the static binary
 COPY . .
-
-# Build the static binary
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-      -ldflags='-w -s -extldflags "-static"' -a \
-      -o /go/bin/hello .
+    -ldflags='-w -s -extldflags "-static"' -a \
+    -o /myapp/hello .
 
 ############################
 # STEP 2 build a small image
@@ -31,7 +34,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
 FROM ${DISTROLESS_IMAGE}
 
 # Copy our static executable
-COPY --from=builder /go/bin/hello /go/bin/hello
+COPY --from=builder /myapp/hello /myapp/hello
 
 # Run the hello binary.
-ENTRYPOINT ["/go/bin/hello"]
+ENTRYPOINT ["/myapp/hello"]:


### PR DESCRIPTION
resolving [issue 32](https://github.com/chemidy/smallest-secured-golang-docker-image/issues/32). Add cache feature to speedup build images and restructure base on Go 1.16 and after.
also provide a alpine-base image for reduce size of image.